### PR TITLE
Spec cleanup

### DIFF
--- a/ansible_tower_client.gemspec
+++ b/ansible_tower_client.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "more_core_extensions"
 
   spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "factory_girl"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 end

--- a/lib/ansible_tower_client/collection_methods.rb
+++ b/lib/ansible_tower_client/collection_methods.rb
@@ -9,13 +9,27 @@ module AnsibleTowerClient
         results += body["results"]
       end
 
-      results.collect { |raw| new(raw) }
+      build_collection(results)
     end
 
     def find(id)
       body = JSON.parse(Api.get("#{endpoint}/#{id}/").body)
       raise ResourceNotFound.new(self, :id => id) if body['id'].nil?
       new(body)
+    end
+
+    private
+
+    def build_collection(results)
+      results.collect do |result|
+        klass = class_from_type(result["type"])
+        klass.new(result)
+      end
+    end
+
+    def class_from_type(type)
+      camelized = type.split("_").collect(&:capitalize).join
+      AnsibleTowerClient.const_get(camelized)
     end
   end
 end

--- a/spec/ad_hoc_command_spec.rb
+++ b/spec/ad_hoc_command_spec.rb
@@ -1,51 +1,38 @@
 require_relative 'spec_helper'
 
 describe AnsibleTowerClient::AdHocCommand do
-  let(:ad_hoc_commands_body) do
-    {:count => 2, :next => nil,
-     :previous => nil,
-     :results => [{:id => 1, :type => 'ad_hoc_command',
-                   :url => '/api/v1/ad_hoc_commands/1/', :name => 'test1'},
-                  {:id => 2, :type => 'ad_hoc_commands',
-                   :url => '/api/v1/ad_hoc_commands/2/', :name => 'test2'}]}.to_json
-  end
-
-  let(:one_result) do
-    {:id => 1, :url => '/api/v1/ad_hoc_commands/1/', :name => 'test1'}.to_json
-  end
-
   let(:api_connection) { instance_double("Faraday::Connection", :get => get) }
+  let(:collection)     { build(:response_collection, :klass => described_class) }
+  let(:instance)       { build(:response_instance,   :klass => described_class) }
 
-  describe '#AdHocCommand.all' do
-    let(:get) { instance_double("Faraday::Result", :body => ad_hoc_commands_body) }
+  context "Collection Methods" do
+    describe '.all' do
+      let(:get) { instance_double("Faraday::Result", :body => collection.to_json) }
 
-    it "returns a list of ad_hoc_command objects" do
-      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      all_ad_hoc_commands = AnsibleTowerClient::AdHocCommand.all
-      expect(all_ad_hoc_commands).to        be_a Array
-      expect(all_ad_hoc_commands.length).to eq(2)
-      expect(all_ad_hoc_commands.first).to  be_a AnsibleTowerClient::AdHocCommand
+      it "returns a collection of objects" do
+        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
+        obj_collection = described_class.all
+        expect(obj_collection).to        be_a Array
+        expect(obj_collection.length).to eq(2)
+        expect(obj_collection.first).to  be_a described_class
+      end
+    end
+
+    describe '.find' do
+      let(:get) { instance_double("Faraday::Result", :body => instance.to_json) }
+
+      it 'returns an instance' do
+        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
+        expect(described_class.find(1)).to be_a described_class
+      end
     end
   end
 
-  describe '#initialize' do
-    it "instantiates an AnsibleTowerClient::AdHocCommand from a hash" do
-      parsed = JSON.parse(ad_hoc_commands_body)['results'].first
-      host = AnsibleTowerClient::AdHocCommand.new(parsed)
-      expect(host).to be_a AnsibleTowerClient::AdHocCommand
-      expect(host.id).to be_a Integer
-      expect(host.name).to eq "test1"
-    end
-  end
+  it "#initialize instantiates an #{described_class} from a hash" do
+    obj = described_class.new(instance)
 
-  describe '#AdHocCommand.find' do
-    let(:get) { instance_double("Faraday::Result", :body => one_result) }
-
-    it 'returns one record' do
-      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      one_thing = AnsibleTowerClient::AdHocCommand.find(1)
-      expect(one_thing).to be_a AnsibleTowerClient::AdHocCommand
-    end
+    expect(obj).to      be_a described_class
+    expect(obj.id).to   be_a Integer
+    expect(obj.name).to be_a String
   end
 end
-

--- a/spec/ad_hoc_command_spec.rb
+++ b/spec/ad_hoc_command_spec.rb
@@ -5,28 +5,7 @@ describe AnsibleTowerClient::AdHocCommand do
   let(:collection)     { build(:response_collection, :klass => described_class) }
   let(:instance)       { build(:response_instance,   :klass => described_class) }
 
-  context "Collection Methods" do
-    describe '.all' do
-      let(:get) { instance_double("Faraday::Result", :body => collection.to_json) }
-
-      it "returns a collection of objects" do
-        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-        obj_collection = described_class.all
-        expect(obj_collection).to        be_a Array
-        expect(obj_collection.length).to eq(2)
-        expect(obj_collection.first).to  be_a described_class
-      end
-    end
-
-    describe '.find' do
-      let(:get) { instance_double("Faraday::Result", :body => instance.to_json) }
-
-      it 'returns an instance' do
-        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-        expect(described_class.find(1)).to be_a described_class
-      end
-    end
-  end
+  include_examples "Collection Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
     obj = described_class.new(instance)

--- a/spec/collection_methods_spec.rb
+++ b/spec/collection_methods_spec.rb
@@ -1,49 +1,13 @@
 require 'spec_helper'
 
 describe AnsibleTowerClient::CollectionMethods do
-  let(:things_body) do
-    {:count => 2, :next => nil,
-     :previous => nil,
-     :results => [{:id => 1,
-                   :url => '/api/v1/things/1/', :name => 'test1'},
-                  {:id => 2,
-                   :url => '/api/v1/things/2/', :name => 'test2'}]}.to_json
-  end
-
-  let(:one_result) do
-    {:id => 1, :url => '/api/v1/things/1/', :name => 'test1'}.to_json
-  end
-
-  let(:api_connection) { instance_double("Faraday::Connection", :get => get) }
-  let(:get) { instance_double("Faraday::Result", :body => things_body) }
-
-  it "#all returns an array of the caller objects" do
-    AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-    all_things = AnsibleTowerClient::JobTemplate.all
-    all_more_things = AnsibleTowerClient::Host.all
-    expect(all_things).to             be_a Array
-    expect(all_things.length).to      eq(2)
-    expect(all_things.first).to       be_a AnsibleTowerClient::JobTemplate
-    expect(all_more_things).to        be_a Array
-    expect(all_more_things.length).to eq(2)
-    expect(all_more_things.first).to  be_a AnsibleTowerClient::Host
-  end
-
   context "#find" do
-    let(:get) { instance_double("Faraday::Result", :body => one_result) }
-    it "returns a record when the id exists" do
-      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      one_thing = AnsibleTowerClient::JobTemplate.find(1)
-      expect(one_thing).to be_a AnsibleTowerClient::JobTemplate
-    end
-  end
-
-  context "#find" do
+    let(:api_connection) { instance_double("Faraday::Connection", :get => get) }
     let(:get) { instance_double("Faraday::Result", :body => {}.to_json) }
+
     it "raises an error when the id does not exist" do
       AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
       expect { AnsibleTowerClient::JobTemplate.find(10) }.to raise_error(AnsibleTowerClient::ResourceNotFound)
     end
   end
 end
-

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -17,5 +17,9 @@ FactoryGirl.define do
     url        { "/api/v1/#{klass.endpoint}/#{id}/" }
 
     initialize_with { AnsibleTowerClient::FactoryHelper.stringify_attribute_keys(attributes) }
+
+    trait(:description) { sequence(:description) { |n| "description_#{n}" } }
+    trait(:extra_vars)  { extra_vars "lots of options" }
+    trait(:instance_id) { instance_id SecureRandom.uuid }
   end
 end

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -1,0 +1,21 @@
+FactoryGirl.define do
+  factory :response_collection, :class => "Hash" do
+    count    2
+    "next"   ""
+    previous ""
+    klass    ""
+    results  { count.times.collect { build(:response_instance, :klass => klass) } }
+
+    initialize_with { AnsibleTowerClient::FactoryHelper.stringify_attribute_keys(attributes) }
+  end
+
+  factory :response_instance, :class => "Hash" do
+    sequence(:id)
+    klass      ""
+    type       { AnsibleTowerClient::FactoryHelper.underscore_string(klass.namespace.last) }
+    name       { "#{type}-#{id}" }
+    url        { "/api/v1/#{klass.endpoint}/#{id}/" }
+
+    initialize_with { AnsibleTowerClient::FactoryHelper.stringify_attribute_keys(attributes) }
+  end
+end

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -5,28 +5,7 @@ describe AnsibleTowerClient::Group do
   let(:collection)     { build(:response_collection, :klass => described_class) }
   let(:instance)       { build(:response_instance,   :klass => described_class) }
 
-  context "Collection Methods" do
-    describe '.all' do
-      let(:get) { instance_double("Faraday::Result", :body => collection.to_json) }
-
-      it "returns a collection of objects" do
-        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-        obj_collection = described_class.all
-        expect(obj_collection).to        be_a Array
-        expect(obj_collection.length).to eq(2)
-        expect(obj_collection.first).to  be_a described_class
-      end
-    end
-
-    describe '.find' do
-      let(:get) { instance_double("Faraday::Result", :body => instance.to_json) }
-
-      it 'returns an instance' do
-        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-        expect(described_class.find(1)).to be_a described_class
-      end
-    end
-  end
+  include_examples "Collection Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
     obj = described_class.new(instance)

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -1,50 +1,38 @@
 require_relative 'spec_helper'
 
 describe AnsibleTowerClient::Group do
-  let(:groups_body) do
-    {:count => 2, :next => nil,
-     :previous => nil,
-     :results => [{:id => 1, :type => 'group',
-                   :url => '/api/v1/groups/1/', :name => 'test1'},
-                  {:id => 2, :type => 'groups',
-                   :url => '/api/v1/groups/2/', :name => 'test2'}]}.to_json
-  end
-
-  let(:one_result) do
-    {:id => 1, :url => '/api/v1/groups/1/', :name => 'test1'}.to_json
-  end
-
   let(:api_connection) { instance_double("Faraday::Connection", :get => get) }
+  let(:collection)     { build(:response_collection, :klass => described_class) }
+  let(:instance)       { build(:response_instance,   :klass => described_class) }
 
-  describe '#Group.all' do
-    let(:get) { instance_double("Faraday::Result", :body => groups_body) }
+  context "Collection Methods" do
+    describe '.all' do
+      let(:get) { instance_double("Faraday::Result", :body => collection.to_json) }
 
-    it "returns a list of group objects" do
-      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      all_groups = AnsibleTowerClient::Group.all
-      expect(all_groups).to        be_a Array
-      expect(all_groups.length).to eq(2)
-      expect(all_groups.first).to  be_a AnsibleTowerClient::Group
+      it "returns a collection of objects" do
+        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
+        obj_collection = described_class.all
+        expect(obj_collection).to        be_a Array
+        expect(obj_collection.length).to eq(2)
+        expect(obj_collection.first).to  be_a described_class
+      end
+    end
+
+    describe '.find' do
+      let(:get) { instance_double("Faraday::Result", :body => instance.to_json) }
+
+      it 'returns an instance' do
+        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
+        expect(described_class.find(1)).to be_a described_class
+      end
     end
   end
 
-  describe '#initialize' do
-    it "instantiates an AnsibleTowerClient::Group from a hash" do
-      parsed = JSON.parse(groups_body)['results'].first
-      host = AnsibleTowerClient::Group.new(parsed)
-      expect(host).to be_a AnsibleTowerClient::Group
-      expect(host.id).to be_a Integer
-      expect(host.name).to eq "test1"
-    end
-  end
+  it "#initialize instantiates an #{described_class} from a hash" do
+    obj = described_class.new(instance)
 
-  describe '#Group.find' do
-    let(:get) { instance_double("Faraday::Result", :body => one_result) }
-
-    it 'returns one record' do
-      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      one_thing = AnsibleTowerClient::Group.find(1)
-      expect(one_thing).to be_a AnsibleTowerClient::Group
-    end
+    expect(obj).to      be_a described_class
+    expect(obj.id).to   be_a Integer
+    expect(obj.name).to be_a String
   end
 end

--- a/spec/host_spec.rb
+++ b/spec/host_spec.rb
@@ -2,38 +2,19 @@ require_relative 'spec_helper'
 require 'json'
 
 describe AnsibleTowerClient::Host do
-  let(:hosts_body) do
-    {:count => 2, :next => nil,
-     :previous => nil,
-     :results => [{:id => 1, :type => 'host', :instance_id => 'asdfad23',
-                   :url => '/api/v1/hosts/1/', :name => 'test1'},
-                  {:id => 2, :type => 'host', :instance_id => '34yufad39',
-                   :url => '/api/v1/hosts/2/', :name => 'test2'}]}.to_json
-  end
-
   let(:api_connection) { instance_double("Faraday::Connection", :get => get) }
+  let(:collection)     { build(:response_collection, :klass => described_class) }
+  let(:instance)       { build(:response_instance, :instance_id, :klass => described_class) }
 
-  describe '#Host.all' do
-    let(:get) { instance_double("Faraday::Result", :body => hosts_body) }
+  include_examples "Collection Methods"
 
-    it "returns a list of host objects" do
-      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      all_hosts = AnsibleTowerClient::Host.all
-      expect(all_hosts).to        be_a Array
-      expect(all_hosts.length).to eq(2)
-      expect(all_hosts.first).to  be_a AnsibleTowerClient::Host
-    end
-  end
+  it "#initialize instantiates an #{described_class} from a hash" do
+    obj = described_class.new(instance)
 
-  describe '#initialize' do
-    it "instantiates an AnsibleTowerClient::Host from a hash" do
-      parsed = JSON.parse(hosts_body)['results'].first
-      host = AnsibleTowerClient::Host.new(parsed)
-      expect(host).to be_a AnsibleTowerClient::Host
-      expect(host.id).to be_a Integer
-      expect(host.url).to be_a String
-      expect(host.instance_id).to be_a String
-      expect(host.name).to eq "test1"
-    end
+    expect(obj).to             be_a described_class
+    expect(obj.id).to          be_a Integer
+    expect(obj.url).to         be_a String
+    expect(obj.instance_id).to be_a String
+    expect(obj.name).to        be_a String
   end
 end

--- a/spec/inventory_spec.rb
+++ b/spec/inventory_spec.rb
@@ -1,50 +1,38 @@
 require_relative 'spec_helper'
 
 describe AnsibleTowerClient::Inventory do
-  let(:inventories_body) do
-    {:count => 2, :next => nil,
-     :previous => nil,
-     :results => [{:id => 1, :type => 'inventory',
-                   :url => '/api/v1/inventories/1/', :name => 'test1'},
-                  {:id => 2, :type => 'inventories',
-                   :url => '/api/v1/inventories/2/', :name => 'test2'}]}.to_json
-  end
-
-  let(:one_result) do
-    {:id => 1, :url => '/api/v1/inventories/1/', :name => 'test1'}.to_json
-  end
-
   let(:api_connection) { instance_double("Faraday::Connection", :get => get) }
+  let(:collection)     { build(:response_collection, :klass => described_class) }
+  let(:instance)       { build(:response_instance,   :klass => described_class) }
 
-  describe '#Inventory.all' do
-    let(:get) { instance_double("Faraday::Result", :body => inventories_body) }
+  context "Collection Methods" do
+    describe '.all' do
+      let(:get) { instance_double("Faraday::Result", :body => collection.to_json) }
 
-    it "returns a list of inventory objects" do
-      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      all_inventories = AnsibleTowerClient::Inventory.all
-      expect(all_inventories).to        be_a Array
-      expect(all_inventories.length).to eq(2)
-      expect(all_inventories.first).to  be_a AnsibleTowerClient::Inventory
+      it "returns a collection of objects" do
+        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
+        obj_collection = described_class.all
+        expect(obj_collection).to        be_a Array
+        expect(obj_collection.length).to eq(2)
+        expect(obj_collection.first).to  be_a described_class
+      end
+    end
+
+    describe '.find' do
+      let(:get) { instance_double("Faraday::Result", :body => instance.to_json) }
+
+      it 'returns an instance' do
+        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
+        expect(described_class.find(1)).to be_a described_class
+      end
     end
   end
 
-  describe '#initialize' do
-    it "instantiates an AnsibleTowerClient::Inventory from a hash" do
-      parsed = JSON.parse(inventories_body)['results'].first
-      host = AnsibleTowerClient::Inventory.new(parsed)
-      expect(host).to be_a AnsibleTowerClient::Inventory
-      expect(host.id).to be_a Integer
-      expect(host.name).to eq "test1"
-    end
-  end
+  it "#initialize instantiates an #{described_class} from a hash" do
+    obj = described_class.new(instance)
 
-  describe '#Inventory.find' do
-    let(:get) { instance_double("Faraday::Result", :body => one_result) }
-
-    it 'returns one record' do
-      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      one_thing = AnsibleTowerClient::Inventory.find(1)
-      expect(one_thing).to be_a AnsibleTowerClient::Inventory
-    end
+    expect(obj).to      be_a described_class
+    expect(obj.id).to   be_a Integer
+    expect(obj.name).to be_a String
   end
 end

--- a/spec/inventory_spec.rb
+++ b/spec/inventory_spec.rb
@@ -5,28 +5,7 @@ describe AnsibleTowerClient::Inventory do
   let(:collection)     { build(:response_collection, :klass => described_class) }
   let(:instance)       { build(:response_instance,   :klass => described_class) }
 
-  context "Collection Methods" do
-    describe '.all' do
-      let(:get) { instance_double("Faraday::Result", :body => collection.to_json) }
-
-      it "returns a collection of objects" do
-        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-        obj_collection = described_class.all
-        expect(obj_collection).to        be_a Array
-        expect(obj_collection.length).to eq(2)
-        expect(obj_collection.first).to  be_a described_class
-      end
-    end
-
-    describe '.find' do
-      let(:get) { instance_double("Faraday::Result", :body => instance.to_json) }
-
-      it 'returns an instance' do
-        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-        expect(described_class.find(1)).to be_a described_class
-      end
-    end
-  end
+  include_examples "Collection Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
     obj = described_class.new(instance)

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -5,28 +5,7 @@ describe AnsibleTowerClient::Job do
   let(:collection)     { build(:response_collection, :klass => described_class) }
   let(:instance)       { build(:response_instance,   :klass => described_class) }
 
-  context "Collection Methods" do
-    describe '.all' do
-      let(:get) { instance_double("Faraday::Result", :body => collection.to_json) }
-
-      it "returns a collection of objects" do
-        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-        obj_collection = described_class.all
-        expect(obj_collection).to        be_a Array
-        expect(obj_collection.length).to eq(2)
-        expect(obj_collection.first).to  be_a described_class
-      end
-    end
-
-    describe '.find' do
-      let(:get) { instance_double("Faraday::Result", :body => instance.to_json) }
-
-      it 'returns an instance' do
-        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-        expect(described_class.find(1)).to be_a described_class
-      end
-    end
-  end
+  include_examples "Collection Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
     obj = described_class.new(instance)

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -1,51 +1,38 @@
 require_relative 'spec_helper'
 
 describe AnsibleTowerClient::Job do
-  let(:jobs_body) do
-    {:count => 2, :next => nil,
-     :previous => nil,
-     :results => [{:id => 1, :type => 'job',
-                   :url => '/api/v1/jobs/1/', :name => 'test1'},
-                  {:id => 2, :type => 'jobs',
-                   :url => '/api/v1/jobs/2/', :name => 'test2'}]}.to_json
-  end
-
-  let(:one_result) do
-    {:id => 1, :url => '/api/v1/jobs/1/', :name => 'test1'}.to_json
-  end
-
   let(:api_connection) { instance_double("Faraday::Connection", :get => get) }
+  let(:collection)     { build(:response_collection, :klass => described_class) }
+  let(:instance)       { build(:response_instance,   :klass => described_class) }
 
-  describe '#Job.all' do
-    let(:get) { instance_double("Faraday::Result", :body => jobs_body) }
+  context "Collection Methods" do
+    describe '.all' do
+      let(:get) { instance_double("Faraday::Result", :body => collection.to_json) }
 
-    it "returns a list of job objects" do
-      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      all_jobs = AnsibleTowerClient::Job.all
-      expect(all_jobs).to        be_a Array
-      expect(all_jobs.length).to eq(2)
-      expect(all_jobs.first).to  be_a AnsibleTowerClient::Job
+      it "returns a collection of objects" do
+        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
+        obj_collection = described_class.all
+        expect(obj_collection).to        be_a Array
+        expect(obj_collection.length).to eq(2)
+        expect(obj_collection.first).to  be_a described_class
+      end
+    end
+
+    describe '.find' do
+      let(:get) { instance_double("Faraday::Result", :body => instance.to_json) }
+
+      it 'returns an instance' do
+        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
+        expect(described_class.find(1)).to be_a described_class
+      end
     end
   end
 
-  describe '#initialize' do
-    it "instantiates an AnsibleTowerClient::Job from a hash" do
-      parsed = JSON.parse(jobs_body)['results'].first
-      host = AnsibleTowerClient::Job.new(parsed)
-      expect(host).to be_a AnsibleTowerClient::Job
-      expect(host.id).to be_a Integer
-      expect(host.name).to eq "test1"
-    end
-  end
+  it "#initialize instantiates an #{described_class} from a hash" do
+    obj = described_class.new(instance)
 
-  describe '#Job.find' do
-    let(:get) { instance_double("Faraday::Result", :body => one_result) }
-
-    it 'returns one record' do
-      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      one_thing = AnsibleTowerClient::Job.find(1)
-      expect(one_thing).to be_a AnsibleTowerClient::Job
-    end
+    expect(obj).to      be_a described_class
+    expect(obj.id).to   be_a Integer
+    expect(obj.name).to be_a String
   end
 end
-

--- a/spec/job_template_spec.rb
+++ b/spec/job_template_spec.rb
@@ -1,86 +1,55 @@
 require_relative 'spec_helper'
 
 describe AnsibleTowerClient::JobTemplate do
-  let(:job_templates_body) do
-    {:count => 2, :next => nil,
-     :previous => nil,
-     :results => [{:id => 1, :type => 'job_template',
-                   :url => '/api/v1/job_templates/1/', :name => 'test1', :description => 'description1'},
-                  {:id => 2, :type => 'job_templates',
-                   :url => '/api/v1/job_templates/2/', :name => 'test2', :description => 'description2'}]}.to_json
-  end
+  let(:api_connection)   { instance_double("Faraday::Connection", :get => get, :post => post) }
+  let(:collection)       { build(:response_collection, :klass => described_class) }
+  let(:instance)         { build(:response_instance, :description, :extra_vars, :klass => described_class) }
+  let(:post)             { instance_double("Faraday::Response", :body => post_result_body.to_json) }
+  let(:post_result_body) { {:job => 1} }
 
-  let(:one_result) do
-    {:id => 1, :url => '/api/v1/job_templates/1/', :name => 'test1',
-     :extra_vars => 'blah', :description => 'description1'}.to_json
-  end
+  context "Collection Methods" do
+    describe '.all' do
+      let(:get) { instance_double("Faraday::Result", :body => collection.to_json) }
 
-  let(:post_result_body) do
-    {:job => 1}.to_json
-  end
+      it "returns a collection of objects" do
+        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
+        obj_collection = described_class.all
+        expect(obj_collection).to        be_a Array
+        expect(obj_collection.length).to eq(2)
+        expect(obj_collection.first).to  be_a described_class
+      end
+    end
 
-  let(:post) { instance_double("Faraday::Response", :body => post_result_body) }
+    describe '.find' do
+      let(:get) { instance_double("Faraday::Result", :body => instance.to_json) }
 
-  let(:api_connection) { instance_double("Faraday::Connection", :get => get, :post => post) }
-
-  describe '#JobTemplate.all' do
-    let(:get) { instance_double("Faraday::Result", :body => job_templates_body) }
-
-    it "returns a list of job_template objects" do
-      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      all_job_templates = AnsibleTowerClient::JobTemplate.all
-      expect(all_job_templates).to        be_a Array
-      expect(all_job_templates.length).to eq(2)
-      expect(all_job_templates.first).to  be_a AnsibleTowerClient::JobTemplate
+      it 'returns an instance' do
+        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
+        expect(described_class.find(1)).to be_a described_class
+      end
     end
   end
 
-  describe '#initialize' do
-    it "instantiates an AnsibleTowerClient::JobTemplate from a hash" do
-      parsed = JSON.parse(job_templates_body)['results'].first
-      host = AnsibleTowerClient::JobTemplate.new(parsed)
-      expect(host).to             be_a AnsibleTowerClient::JobTemplate
-      expect(host.id).to          be_a Integer
-      expect(host.name).to        eq "test1"
-      expect(host.description).to eq "description1"
-    end
+  it "#initialize instantiates an #{described_class} from a hash" do
+    obj = described_class.new(instance)
+
+    expect(obj).to             be_a described_class
+    expect(obj.id).to          be_a Integer
+    expect(obj.name).to        be_a String
+    expect(obj.description).to be_a String
+    expect(obj.extra_vars).to  eq("lots of options")
   end
 
   describe '#launch' do
-    let(:get) { instance_double("Faraday::Result", :body => one_result) }
-    let(:json) do
-      {'extra_vars' => "{\"instance_ids\":[\"i-999c\"],\"state\":\"absent\",\"subnet_id\":\"subnet-887\"}"}
-    end
+    let(:get)  { instance_double("Faraday::Result", :body => instance.to_json) }
+    let(:json) { {'extra_vars' => "{\"instance_ids\":[\"i-999c\"],\"state\":\"absent\",\"subnet_id\":\"subnet-887\"}"} }
 
     it "runs an existing job template" do
       AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      parsed = JSON.parse(job_templates_body)['results'].first
-      host = AnsibleTowerClient::JobTemplate.new(parsed)
-      resp = host.launch(json)
-      expect(resp).to be_a AnsibleTowerClient::Job
-      expect(resp.id).to eq 1
-    end
-  end
 
-  describe '#extra_vars' do
-    let(:get) { instance_double("Faraday::Result", :body => one_result) }
+      expect(AnsibleTowerClient::Job).to receive(:find).with(post_result_body[:job])
 
-    it 'displays extra_vars on a job template' do
-      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      one_thing = AnsibleTowerClient::JobTemplate.find(1)
-      expect(one_thing.extra_vars).to be_a String
-      expect(one_thing.extra_vars).to eq "blah"
-    end
-  end
-
-  describe '#JobTemplate.find' do
-    let(:get) { instance_double("Faraday::Result", :body => one_result) }
-
-    it 'returns one record' do
-      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-      one_thing = AnsibleTowerClient::JobTemplate.find(1)
-      expect(one_thing).to be_a AnsibleTowerClient::JobTemplate
+      described_class.new(instance).launch(json)
     end
   end
 end
-

--- a/spec/job_template_spec.rb
+++ b/spec/job_template_spec.rb
@@ -7,28 +7,7 @@ describe AnsibleTowerClient::JobTemplate do
   let(:post)             { instance_double("Faraday::Response", :body => post_result_body.to_json) }
   let(:post_result_body) { {:job => 1} }
 
-  context "Collection Methods" do
-    describe '.all' do
-      let(:get) { instance_double("Faraday::Result", :body => collection.to_json) }
-
-      it "returns a collection of objects" do
-        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-        obj_collection = described_class.all
-        expect(obj_collection).to        be_a Array
-        expect(obj_collection.length).to eq(2)
-        expect(obj_collection.first).to  be_a described_class
-      end
-    end
-
-    describe '.find' do
-      let(:get) { instance_double("Faraday::Result", :body => instance.to_json) }
-
-      it 'returns an instance' do
-        AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
-        expect(described_class.find(1)).to be_a described_class
-      end
-    end
-  end
+  include_examples "Collection Methods"
 
   it "#initialize instantiates an #{described_class} from a hash" do
     obj = described_class.new(instance)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,13 @@
+gem_root = Gem::Specification.find_by_name("ansible_tower_client").gem_dir
+Dir[File.join(gem_root, "spec/support/**/*.rb")].each { |f| require f }
+
+require 'factory_girl'
+FactoryGirl.find_definitions
+
+RSpec.configure do |config|
+  config.order = :random
+  config.include FactoryGirl::Syntax::Methods
+end
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'ansible_tower_client'

--- a/spec/support/factory_helper.rb
+++ b/spec/support/factory_helper.rb
@@ -1,7 +1,9 @@
+require 'securerandom'
+
 module AnsibleTowerClient
   module FactoryHelper
     def self.stringify_attribute_keys(hash)
-      [:description, :extra_vars, :id, :name, :results, :type, :url].each do |attribute|
+      [:description, :extra_vars, :id, :instance_id, :name, :results, :type, :url].each do |attribute|
         val = hash.delete(attribute)
         hash[attribute.to_s] = val if val
       end

--- a/spec/support/factory_helper.rb
+++ b/spec/support/factory_helper.rb
@@ -1,0 +1,16 @@
+module AnsibleTowerClient
+  module FactoryHelper
+    def self.stringify_attribute_keys(hash)
+      [:description, :extra_vars, :id, :name, :results, :type, :url].each do |attribute|
+        val = hash.delete(attribute)
+        hash[attribute.to_s] = val if val
+      end
+      hash.delete(:klass)
+      hash
+    end
+
+    def self.underscore_string(string)
+      string.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
+    end
+  end
+end

--- a/spec/support/shared_examples/collection_methods.rb
+++ b/spec/support/shared_examples/collection_methods.rb
@@ -1,0 +1,22 @@
+shared_examples_for "Collection Methods" do
+  describe '.all' do
+    let(:get) { instance_double("Faraday::Result", :body => collection.to_json) }
+
+    it "returns a collection of objects" do
+      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
+      obj_collection = described_class.all
+      expect(obj_collection).to        be_a Array
+      expect(obj_collection.length).to eq(2)
+      expect(obj_collection.first).to  be_a described_class
+    end
+  end
+
+  describe '.find' do
+    let(:get) { instance_double("Faraday::Result", :body => instance.to_json) }
+
+    it 'returns an instance' do
+      AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
+      expect(described_class.find(1)).to be_a described_class
+    end
+  end
+end


### PR DESCRIPTION
Ensure collections are built with the correct type.

Fix lots of spec failures due to this change.
Add FactoryGirl and reduce duplication through factories and shared_examples