### PR TITLE
Extra vars changes in job_template

### DIFF
--- a/lib/ansible_tower_client/job_template.rb
+++ b/lib/ansible_tower_client/job_template.rb
@@ -14,7 +14,8 @@ module AnsibleTowerClient
     def launch(vars = {})
       launch_url = "#{url}launch/"
       extra = JSONValues.new(vars).extra_vars
-      resp = Api.post(launch_url, extra).body
+      extra_vars = {"extra_vars": extra.to_json}
+      resp = Api.post(launch_url, extra_vars).body
       job = JSON.parse(resp)
       Job.find(job['job'])
     end


### PR DESCRIPTION
The extra_vars key needs to be passed to
Tower as a hash key with JSON values.

This resolves an issue where the passed in
extra_vars were not being applied to the
template being launched against.