### PR TITLE
Return survey_spec as a string

### DIFF
--- a/lib/ansible_tower_client/job_template.rb
+++ b/lib/ansible_tower_client/job_template.rb
@@ -22,7 +22,7 @@ module AnsibleTowerClient
     def survey_spec
       spec_url = related['survey_spec']
       return nil unless spec_url
-      JSON.parse(Api.get(spec_url).body)
+      Api.get(spec_url).body
     end
 
     def self.endpoint

--- a/spec/job_template_spec.rb
+++ b/spec/job_template_spec.rb
@@ -40,8 +40,8 @@ describe AnsibleTowerClient::JobTemplate do
       it "returns a survey spec" do
         AnsibleTowerClient::Api.instance_variable_set(:@instance, api_connection)
         survey = described_class.new(instance).survey_spec
-        expect(survey).to be_a Hash
-        expect(survey).to eq 'description' => 'blah'
+        expect(survey).to be_a String
+        expect(survey).to eq "{\"description\":\"blah\"}"
       end
     end
 


### PR DESCRIPTION
We currently return extra_vars as a raw string.
Survey_spec was returned as a JSON.parsed Hash.
The app is expecting to save a raw string - identical to extra_vars
This simply makes the two attributes more alike.