### PR TITLE
Added with_temporary_changes to handle updating limit

### DIFF
--- a/lib/ansible_tower_client/job_template.rb
+++ b/lib/ansible_tower_client/job_template.rb
@@ -1,10 +1,14 @@
 module AnsibleTowerClient
   class JobTemplate < BaseModel
-    def launch(vars = {})
+    def launch(options = {})
       launch_url = "#{url}launch/"
-      extra = JSONValues.new(vars).extra_vars
-      resp = api.post(launch_url, extra).body
-      job = JSON.parse(resp)
+      options = options.dup
+      new_limit = options.delete('limit')
+      response = with_temporary_changes(new_limit) do
+        api.post(launch_url, options).body
+      end
+
+      job = JSON.parse(response)
       api.jobs.find(job['job'])
     end
 
@@ -16,6 +20,27 @@ module AnsibleTowerClient
 
     def self.endpoint
       "job_templates".freeze
+    end
+
+    private
+
+    def with_temporary_changes(in_limit)
+      old_limit = limit
+      new_limit = in_limit
+      patch("{ \"limit\": \"#{new_limit}\" }")
+      begin
+        yield
+      ensure
+        patch("{ \"limit\": \"#{old_limit}\" }")
+      end
+    end
+
+    def patch(body)
+      api.patch do |req|
+        req.url(url)
+        req.headers['Content-Type'] = 'application/json'
+        req.body = body
+      end
     end
   end
 end

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -16,6 +16,7 @@ FactoryGirl.define do
     name       { "#{type}-#{id}" }
     url        { "/api/v1/#{klass.endpoint}/#{id}/" }
     related    { {"survey_spec" => "example.com/api", 'inventory' => 'inventory link'} }
+    limit      { "default" }
 
     trait(:description)             { sequence(:description) { |n| "description_#{n}" } }
     trait(:extra_vars)              { extra_vars "lots of options" }

--- a/spec/job_template_spec.rb
+++ b/spec/job_template_spec.rb
@@ -22,13 +22,20 @@ describe AnsibleTowerClient::JobTemplate do
 
   describe '#launch' do
     let(:json) { {'extra_vars' => "{\"instance_ids\":[\"i-999c\"],\"state\":\"absent\",\"subnet_id\":\"subnet-887\"}"} }
+    let(:limit) { 'test' }
     let(:post_result_body) { {:job => 1} }
 
     it "runs an existing job template" do
       expect_any_instance_of(AnsibleTowerClient::Collection).to receive(:find).with(post_result_body[:job])
       expect(api).to receive(:post).and_return(instance_double("Faraday::Response", :body => post_result_body.to_json))
+      expect(api).to receive(:patch).twice.and_return(instance_double("Faraday::Response", :body => post_result_body.to_json))
 
       described_class.new(api, raw_instance).launch(json)
+    end
+
+    it "handles limit when passed in" do
+      expect_any_instance_of(AnsibleTowerClient::JobTemplate).to receive(:patch).twice
+      described_class.new(api, raw_instance).send(:with_temporary_changes, limit) { '' }
     end
   end
 


### PR DESCRIPTION
1. Pass the post url with extra_vars into a block
2. Make a separate patch call to update the limit
3. Yield the original launch restful call
4. Ensure the limit is set back to what it originally was.