### PR TITLE
Create find_all_by_url method

### DIFF
--- a/lib/ansible_tower_client/collection.rb
+++ b/lib/ansible_tower_client/collection.rb
@@ -7,7 +7,11 @@ module AnsibleTowerClient
     end
 
     def all
-      collection_for(api.get(klass.endpoint))
+      find_all_by_url(klass.endpoint)
+    end
+
+    def find_all_by_url(url)
+      collection_for(api.get(url))
     end
 
     def collection_for(paginated_result)

--- a/lib/ansible_tower_client/inventory.rb
+++ b/lib/ansible_tower_client/inventory.rb
@@ -5,7 +5,7 @@ module AnsibleTowerClient
     end
 
     def root_groups
-      self.class.collection_for(api.get(File.join(self.class.endpoint, id.to_s, "root_groups")))
+      api.inventories.find_all_by_url(related['root_groups'])
     end
   end
 end

--- a/spec/ad_hoc_command_spec.rb
+++ b/spec/ad_hoc_command_spec.rb
@@ -1,10 +1,12 @@
 require_relative 'spec_helper'
 
 describe AnsibleTowerClient::AdHocCommand do
-  let(:api)            { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)     { api.ad_hoc_commands }
-  let(:raw_collection) { build(:response_collection, :klass => described_class) }
-  let(:raw_instance)   { build(:response_instance,   :klass => described_class) }
+  let(:url)                 { "example.com/api/v1/ad_hoc_command_update/10" }
+  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
+  let(:collection)          { api.ad_hoc_commands }
+  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
+  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
+  let(:raw_instance)        { build(:response_instance, :klass => described_class) }
 
   include_examples "Collection Methods"
 

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -9,6 +9,17 @@ FactoryGirl.define do
     initialize_with { AnsibleTowerClient::FactoryHelper.stringify_attribute_keys(attributes) }
   end
 
+  factory :response_url_collection, :class => "Hash" do
+    count    1
+    "next"   ""
+    previous ""
+    klass    ""
+    url      ""
+    results  { count.times.collect { build(:response_instance, :klass => klass, :url => url) } }
+
+    initialize_with { AnsibleTowerClient::FactoryHelper.stringify_attribute_keys(attributes) }
+  end
+
   factory :response_instance, :class => "Hash" do
     sequence(:id)
     klass      ""
@@ -26,6 +37,7 @@ FactoryGirl.define do
     trait(:group)                   { [description, inventory_id] }
     trait(:host)                    { [description, instance_id, inventory_id] }
     trait(:job_template)            { [description, extra_vars] }
+    trait(:url)                     { "/api/v1/#{klass}/#{rand(10)}" }
 
     initialize_with { AnsibleTowerClient::FactoryHelper.stringify_attribute_keys(attributes) }
   end

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -1,10 +1,12 @@
 require_relative 'spec_helper'
 
 describe AnsibleTowerClient::Group do
-  let(:api)            { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)     { api.groups }
-  let(:raw_collection) { build(:response_collection, :klass => described_class) }
-  let(:raw_instance)   { build(:response_instance, :group, :klass => described_class) }
+  let(:url)                 { "example.com/api/v1/group_update/10" }
+  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
+  let(:collection)          { api.groups }
+  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
+  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
+  let(:raw_instance)        { build(:response_instance, :group, :klass => described_class) }
 
   include_examples "Collection Methods"
 

--- a/spec/host_spec.rb
+++ b/spec/host_spec.rb
@@ -2,10 +2,12 @@ require_relative 'spec_helper'
 require 'json'
 
 describe AnsibleTowerClient::Host do
-  let(:api)            { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)     { api.hosts }
-  let(:raw_collection) { build(:response_collection, :klass => described_class) }
-  let(:raw_instance)   { build(:response_instance, :host, :klass => described_class) }
+  let(:url)                 { "example.com/api/v1/host_update/10" }
+  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
+  let(:collection)          { api.hosts }
+  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
+  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
+  let(:raw_instance)        { build(:response_instance, :host, :klass => described_class) }
 
   include_examples "Collection Methods"
 

--- a/spec/inventory_spec.rb
+++ b/spec/inventory_spec.rb
@@ -1,10 +1,12 @@
 require_relative 'spec_helper'
 
 describe AnsibleTowerClient::Inventory do
-  let(:api)            { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)     { api.inventories }
-  let(:raw_collection) { build(:response_collection, :klass => described_class) }
-  let(:raw_instance)   { build(:response_instance,   :klass => described_class) }
+  let(:url)                 { "example.com/api/v1/update_inventory/10" }
+  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
+  let(:collection)          { api.inventories }
+  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
+  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
+  let(:raw_instance)        { build(:response_instance, :klass => described_class) }
 
   include_examples "Collection Methods"
 

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -1,10 +1,12 @@
 require_relative 'spec_helper'
 
 describe AnsibleTowerClient::Job do
-  let(:api)            { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)     { api.jobs }
-  let(:raw_collection) { build(:response_collection, :klass => described_class) }
-  let(:raw_instance)   { build(:response_instance,   :klass => described_class) }
+  let(:url)                 { "example.com/api/v1/job_update/10" }
+  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
+  let(:collection)          { api.jobs }
+  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
+  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
+  let(:raw_instance)        { build(:response_instance, :klass => described_class) }
 
   include_examples "Collection Methods"
 

--- a/spec/job_template_spec.rb
+++ b/spec/job_template_spec.rb
@@ -1,12 +1,14 @@
 require_relative 'spec_helper'
 
 describe AnsibleTowerClient::JobTemplate do
-  let(:api)              { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
-  let(:collection)       { api.job_templates }
-  let(:raw_collection)   { build(:response_collection, :klass => described_class) }
-  let(:raw_instance)     { build(:response_instance, :job_template, :klass => described_class) }
+  let(:url)                 { "example.com/api/v1/job_template_update/10" }
+  let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }
+  let(:collection)          { api.job_templates }
+  let(:raw_collection)      { build(:response_collection, :klass => described_class) }
+  let(:raw_url_collection)  { build(:response_url_collection, :klass => described_class, :url => url) }
+  let(:raw_instance)        { build(:response_instance, :job_template, :klass => described_class) }
   let(:raw_instance_no_extra_vars) { build(:response_instance, :job_template, :klass => described_class, :extra_vars => '') }
-  let(:raw_instance_no_survey) { build(:response_instance, :job_template, :klass => described_class, :related => {}) }
+  let(:raw_instance_no_survey)     { build(:response_instance, :job_template, :klass => described_class, :related => {}) }
 
   include_examples "Collection Methods"
 

--- a/spec/support/shared_examples/collection_methods.rb
+++ b/spec/support/shared_examples/collection_methods.rb
@@ -8,6 +8,17 @@ shared_examples_for "Collection Methods" do
     expect(obj_collection.first).to  be_a described_class
   end
 
+  it ".find_all_by_url returns a collection of objects via a url" do
+    expect(api).to receive(:get).and_return(instance_double("Faraday::Result", :body => raw_url_collection.to_json))
+    url = raw_url_collection['url']
+
+    obj_collection = collection.find_all_by_url(url)
+    expect(obj_collection).to        be_a Array
+    expect(obj_collection.length).to eq(1)
+    expect(obj_collection.first).to  be_a described_class
+    expect(obj_collection.first.url).to eq url
+  end
+
   it ".find returns an instance" do
     expect(api).to receive(:get).and_return(instance_double("Faraday::Result", :body => raw_instance.to_json))
 


### PR DESCRIPTION
Extract the behavior of the Collection#all method
into find_all_by_url so we can use the same behavior
with any url passed in.

Collection#all now calls find_all_by_url.
by passing in klass.endpoint as an argument.