### PR TITLE
Change Collection to use lazy enumerators

### DIFF
--- a/lib/ansible_tower_client/group.rb
+++ b/lib/ansible_tower_client/group.rb
@@ -5,7 +5,7 @@ module AnsibleTowerClient
     end
 
     def children
-      self.class.collection_for(api.get(File.join(self.class.endpoint, id.to_s, "children")))
+      self.class.find_all_by_url(File.join(self.class.endpoint, id.to_s, "children"))
     end
   end
 end

--- a/lib/ansible_tower_client/group.rb
+++ b/lib/ansible_tower_client/group.rb
@@ -5,7 +5,7 @@ module AnsibleTowerClient
     end
 
     def children
-      self.class.find_all_by_url(File.join(self.class.endpoint, id.to_s, "children"))
+      Collection.new(api).find_all_by_url(related["children"])
     end
   end
 end

--- a/lib/ansible_tower_client/host.rb
+++ b/lib/ansible_tower_client/host.rb
@@ -5,7 +5,7 @@ module AnsibleTowerClient
     end
 
     def groups
-      self.class.find_all_by_url(File.join(self.class.endpoint, id.to_s, "groups"))
+      Collection.new(api).find_all_by_url(related["groups"])
     end
   end
 end

--- a/lib/ansible_tower_client/host.rb
+++ b/lib/ansible_tower_client/host.rb
@@ -5,7 +5,7 @@ module AnsibleTowerClient
     end
 
     def groups
-      self.class.collection_for(api.get(File.join(self.class.endpoint, id.to_s, "groups")))
+      self.class.find_all_by_url(File.join(self.class.endpoint, id.to_s, "groups"))
     end
   end
 end

--- a/lib/ansible_tower_client/inventory.rb
+++ b/lib/ansible_tower_client/inventory.rb
@@ -5,7 +5,7 @@ module AnsibleTowerClient
     end
 
     def root_groups
-      api.inventories.find_all_by_url(related['root_groups'])
+      Collection.new(api).find_all_by_url(related['root_groups'])
     end
   end
 end

--- a/spec/support/shared_examples/collection_methods.rb
+++ b/spec/support/shared_examples/collection_methods.rb
@@ -1,11 +1,8 @@
 shared_examples_for "Collection Methods" do
   it ".all returns a collection of objects" do
-    expect(api).to receive(:get).and_return(instance_double("Faraday::Result", :body => raw_collection.to_json))
+    expect(collection).to receive(:find_all_by_url).with(described_class.endpoint)
 
-    obj_collection = collection.all
-    expect(obj_collection).to        be_a Array
-    expect(obj_collection.length).to eq(2)
-    expect(obj_collection.first).to  be_a described_class
+    collection.all
   end
 
   it ".find_all_by_url returns a collection of objects via a url" do

--- a/spec/support/shared_examples/collection_methods.rb
+++ b/spec/support/shared_examples/collection_methods.rb
@@ -1,5 +1,5 @@
 shared_examples_for "Collection Methods" do
-  it ".all returns a collection of objects" do
+  it ".all returns an enumerator that will delay load a collection" do
     expect(collection).to receive(:find_all_by_url).with(described_class.endpoint)
 
     collection.all
@@ -10,10 +10,12 @@ shared_examples_for "Collection Methods" do
     url = raw_url_collection['url']
 
     obj_collection = collection.find_all_by_url(url)
-    expect(obj_collection).to        be_a Array
-    expect(obj_collection.length).to eq(1)
-    expect(obj_collection.first).to  be_a described_class
-    expect(obj_collection.first.url).to eq url
+    expect(obj_collection).to be_a Enumerator
+
+    obj_collection_array = obj_collection.to_a
+    expect(obj_collection_array.length).to    eq(1)
+    expect(obj_collection_array.first).to     be_a described_class
+    expect(obj_collection_array.first.url).to eq(url)
   end
 
   it ".find returns an instance" do


### PR DESCRIPTION
### Better handle paging
Rewrite collections to return lazy Enumerators instead of Arrays

Break out:
- response parsing
- result set parsing
- building objects out of results
- fetching pages

Merge #find_all_by_url and #collection_for after refactoring

Lazy Enumerators allow for quicker initial response since a page is only requested and its objects created when needed rather than fetching all pages at once then creating objects from each result.

Make 'klass' optional since it is only required for #find

Update Collection specs accordingly


### Problems
##### Solved:
- The old solution is only going to get slower as the amount of collection items increases
- Long initial delay before chained methods (collect, each) can start processing
- The old solution will fetch all records even if we only care about the first N

##### Created?
- `all` returns an enumerable instead of an Array

_old solution = Fetching all pages, then turning everything in the collection into objects_