### PR TITLE
Limit ActiveSupport version if Ruby version is less than 2.2.2

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/ansible_tower_client.gemspec
+++ b/ansible_tower_client.gemspec
@@ -19,10 +19,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  # HACK: Rails 5 dropped support for Ruby < 2.2.2
+  active_support_version = "< 5" if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.2.2")
+  spec.add_runtime_dependency "activesupport", active_support_version
+
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "faraday_middleware"
-  spec.add_runtime_dependency "more_core_extensions"
-  spec.add_runtime_dependency 'activesupport', '>= 1.2.0'
+  spec.add_runtime_dependency "more_core_extensions", "~> 3.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "byebug"

--- a/spec/ad_hoc_command_spec.rb
+++ b/spec/ad_hoc_command_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'spec_helper'
-
 describe AnsibleTowerClient::AdHocCommand do
   let(:url)                 { "example.com/api/v1/ad_hoc_command_update/10" }
   let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -1,4 +1,3 @@
-require_relative 'spec_helper'
 require 'json'
 
 describe AnsibleTowerClient::Api do

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -1,4 +1,3 @@
-require_relative 'spec_helper'
 require 'json'
 
 describe AnsibleTowerClient::Connection do

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'spec_helper'
-
 describe AnsibleTowerClient::Group do
   let(:url)                 { "example.com/api/v1/group_update/10" }
   let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }

--- a/spec/host_spec.rb
+++ b/spec/host_spec.rb
@@ -1,4 +1,3 @@
-require_relative 'spec_helper'
 require 'json'
 
 describe AnsibleTowerClient::Host do

--- a/spec/inventory_source_spec.rb
+++ b/spec/inventory_source_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'spec_helper'
-
 describe AnsibleTowerClient::InventorySource do
   let(:url)                 { "example.com/api/v1/inventory_source/10" }
   let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }

--- a/spec/inventory_spec.rb
+++ b/spec/inventory_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'spec_helper'
-
 describe AnsibleTowerClient::Inventory do
   let(:url)                 { "example.com/api/v1/inventory_sources" }
   let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }

--- a/spec/inventory_update_spec.rb
+++ b/spec/inventory_update_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'spec_helper'
-
 describe AnsibleTowerClient::InventoryUpdate do
   let(:url)                 { "example.com/api/v1/inventory_update/10" }
   let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'spec_helper'
-
 describe AnsibleTowerClient::Job do
   let(:url)            { "example.com/api/v1/job_update/10" }
   let(:api)            { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }

--- a/spec/job_template_spec.rb
+++ b/spec/job_template_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'spec_helper'
-
 describe AnsibleTowerClient::JobTemplate do
   let(:url)                 { "example.com/api/v1/job_template_update/10" }
   let(:api)                 { AnsibleTowerClient::Api.new(instance_double("Faraday::Connection")) }

--- a/spec/null_logger_spec.rb
+++ b/spec/null_logger_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe AnsibleTowerClient::NullLogger do
   it "returns a null logger" do
     expect(AnsibleTowerClient.logger).to be_a AnsibleTowerClient::NullLogger


### PR DESCRIPTION
Rails 5 isn't compatible with older rubies.
Upgrade more_core_extensions to provide `blank?`