### PR TITLE
Ensure we always set content_type of "application/json"

### DIFF
--- a/lib/ansible_tower_client/connection.rb
+++ b/lib/ansible_tower_client/connection.rb
@@ -13,7 +13,8 @@ module AnsibleTowerClient
       require 'ansible_tower_client/middleware/raise_tower_error'
       Faraday::Response.register_middleware :raise_tower_error => -> { Middleware::RaiseTowerError }
       @connection = Faraday.new(options[:base_url], :ssl => {:verify => verify_ssl}) do |f|
-        f.use FaradayMiddleware::FollowRedirects, :limit => 3, :standards_compliant => true
+        f.use(FaradayMiddleware::EncodeJson)
+        f.use(FaradayMiddleware::FollowRedirects, :limit => 3, :standards_compliant => true)
         f.request(:url_encoded)
         f.response(:raise_tower_error)
         f.adapter(Faraday.default_adapter)


### PR DESCRIPTION
Fixes error:
unsupported media type "application/x-www-form-urlencoded" in request

https://bugzilla.redhat.com/show_bug.cgi?id=1348500