### PR TITLE
Rescue client errors

### DIFF
--- a/lib/ansible_tower_client.rb
+++ b/lib/ansible_tower_client.rb
@@ -1,5 +1,6 @@
 require "json"
 require "yaml"
+require "ansible_tower_client/exception"
 require "ansible_tower_client/logging"
 require "ansible_tower_client/null_logger"
 require "ansible_tower_client/version"

--- a/lib/ansible_tower_client/api.rb
+++ b/lib/ansible_tower_client/api.rb
@@ -39,6 +39,12 @@ module AnsibleTowerClient
 
     def method_missing(method_name, *args, &block)
       instance.respond_to?(method_name) ? instance.send(method_name, *args, &block) : super
+    rescue Faraday::ConnectionFailed, Faraday::SSLError => err
+      raise
+    rescue Faraday::ClientError => err
+      message = JSON.parse(err.message)['detail'] rescue nil
+      message ||= "An unknown error was returned from the provider"
+      raise AnsibleTowerClient::ConnectionError, message
     end
 
     def respond_to_missing?(method, _include_private = false)

--- a/lib/ansible_tower_client/exception.rb
+++ b/lib/ansible_tower_client/exception.rb
@@ -1,0 +1,3 @@
+module AnsibleTowerClient
+  class ConnectionError < Exception; end
+end


### PR DESCRIPTION
Based on [these changes](https://github.com/ManageIQ/manageiq/pull/8947)
Attempt to JSON parse the error message and if it fails, return a generic message.  Rescue `Faraday::ConnectionFailed` and `Faraday::SSLError` and re-raise them first since they inherit from `Faraday::ConnectionError`.