### PR TITLE
Move activesupport hack to Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ansible_tower_client.gemspec
 gemspec
+
+# HACK: Rails 5 dropped support for Ruby < 2.2.2
+active_support_version = "< 5" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.2.2")
+gem "activesupport", active_support_version

--- a/ansible_tower_client.gemspec
+++ b/ansible_tower_client.gemspec
@@ -19,10 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # HACK: Rails 5 dropped support for Ruby < 2.2.2
-  active_support_version = "< 5" if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.2.2")
-  spec.add_runtime_dependency "activesupport", active_support_version
-
+  spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "faraday_middleware"
   spec.add_runtime_dependency "more_core_extensions", "~> 3.0"


### PR DESCRIPTION
Allow tests to run with the correct version of activesupport for their
ruby version.